### PR TITLE
Bugfix-drive

### DIFF
--- a/scripts/operation/drive/subir_archivo_2.0.0.py
+++ b/scripts/operation/drive/subir_archivo_2.0.0.py
@@ -98,14 +98,15 @@ def Try_Autenticar_Drive(SCOPES, credentials_file, token_file, logger):
 
 
 # Función para inicializar y obtener el logger de un cliente
-def obtener_logger(id_estacion, log_directory):
+def obtener_logger(id_estacion, log_directory, log_filename):
     global loggers
     if id_estacion not in loggers:
         # Crear un logger para el cliente
         logger = logging.getLogger(id_estacion)
         logger.setLevel(logging.DEBUG)
-        # Crear manejador de archivo
-        log_path = os.path.join(log_directory, f"{id_estacion}_drive.log")
+        # Ruta completa del archivo de log
+        log_path = os.path.join(log_directory, log_filename)
+        # Crear manejador de archivo, apuntando al archivo existente
         file_handler = logging.FileHandler(log_path)
         file_handler.setLevel(logging.DEBUG)
         # Crear formato de logging y añadirlo al manejador
@@ -174,7 +175,7 @@ def main():
         os.makedirs(log_directory)
 
     # Inicializa el logger
-    logger = obtener_logger(id_estacion, log_directory)
+    logger = obtener_logger(id_estacion, log_directory, "drive.log")
 
     # Verifica si el archivo existe
     if not os.path.isfile(path_completo_archivo):

--- a/scripts/operation/drive/subir_pendientes_drive.py
+++ b/scripts/operation/drive/subir_pendientes_drive.py
@@ -1,0 +1,33 @@
+import os
+import subprocess
+
+def main():
+    # Obtiene la variable de entorno para definir la ruta del archivo de configuracion:
+    project_local_root = os.getenv("PROJECT_LOCAL_ROOT")
+    if project_local_root:
+        # Concatenar PROJECT_LOCAL_ROOT con las diferentes rutas de los archivos y scripts:
+        script_subir_archivo_drive = os.path.join(project_local_root, "scripts", "drive", "subir_archivo.py")
+        mseed_directory = os.path.join(project_local_root, "resultados", "mseed")
+    else:
+        print("La variable de entorno no está definida.")
+        return
+
+    # Verificar si el directorio existe
+    if not os.path.exists(mseed_directory):
+        print(f"El directorio {mseed_directory} no existe.")
+        return
+
+    # Escanear el contenido del directorio
+    archivos_mseed = [f for f in os.listdir(mseed_directory) if f.endswith(".mseed")]
+
+    # Subir cada archivo a Google Drive
+    if archivos_mseed:
+        for nombre_archivo_mseed in archivos_mseed:
+            #ruta_archivo_mseed = os.path.join(mseed_directory, nombre_archivo_mseed)
+            print(f"Subiendo el archivo: {nombre_archivo_mseed}")
+            subprocess.run(["python3", script_subir_archivo_drive, nombre_archivo_mseed, "3", "1"])
+    else:
+        print("No se encontraron archivos .mseed en el directorio especificado.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup/deploy.sh
+++ b/scripts/setup/deploy.sh
@@ -26,6 +26,9 @@ chown -R $USER:$USER $PROJECT_LOCAL_ROOT
 echo $(date) > $PROJECT_LOCAL_ROOT/resultados/registro-continuo/nueva-estacion.txt
 echo 'nueva-estacion.txt' > $PROJECT_LOCAL_ROOT/tmp-files/NombreArchivoRegistroContinuo.tmp
 
+# Crea los archivos log
+touch $PROJECT_LOCAL_ROOT/log-files/drive.log
+
 # Copiar los archivos de configuración del proyecto en Git al proyecto local
 cp $PROJECT_GIT_ROOT/configuration/configuracion_dispositivo.json $PROJECT_LOCAL_ROOT/configuracion/
 cp $PROJECT_GIT_ROOT/configuration/configuracion_mqtt.json $PROJECT_LOCAL_ROOT/configuracion/
@@ -35,6 +38,7 @@ cp $PROJECT_GIT_ROOT/configuration/configuracion_mseed.json $PROJECT_LOCAL_ROOT/
 cp $PROJECT_GIT_ROOT/scripts/operation/mqtt/cliente*.py $PROJECT_LOCAL_ROOT/scripts/mqtt/cliente.py
 cp $PROJECT_GIT_ROOT/scripts/operation/mseed/binary_to_mseed*.py $PROJECT_LOCAL_ROOT/scripts/mseed/binary_to_mseed.py
 cp $PROJECT_GIT_ROOT/scripts/operation/drive/subir_archivo*.py $PROJECT_LOCAL_ROOT/scripts/drive/subir_archivo.py
+cp $PROJECT_GIT_ROOT/scripts/operation/drive/subir_pendientes_drive*.py $PROJECT_LOCAL_ROOT/scripts/drive/subir_archivos_pendientes.py
 
 # Copiar el task-script crontab.txt al directorio de proyectos
 cp $PROJECT_GIT_ROOT/scripts/task/crontab.txt $PROJECT_LOCAL_ROOT/scripts/task/

--- a/scripts/setup/deploy.sh
+++ b/scripts/setup/deploy.sh
@@ -38,7 +38,7 @@ cp $PROJECT_GIT_ROOT/configuration/configuracion_mseed.json $PROJECT_LOCAL_ROOT/
 cp $PROJECT_GIT_ROOT/scripts/operation/mqtt/cliente*.py $PROJECT_LOCAL_ROOT/scripts/mqtt/cliente.py
 cp $PROJECT_GIT_ROOT/scripts/operation/mseed/binary_to_mseed*.py $PROJECT_LOCAL_ROOT/scripts/mseed/binary_to_mseed.py
 cp $PROJECT_GIT_ROOT/scripts/operation/drive/subir_archivo*.py $PROJECT_LOCAL_ROOT/scripts/drive/subir_archivo.py
-cp $PROJECT_GIT_ROOT/scripts/operation/drive/subir_pendientes_drive*.py $PROJECT_LOCAL_ROOT/scripts/drive/subir_archivos_pendientes.py
+cp $PROJECT_GIT_ROOT/scripts/operation/drive/subir_pendientes_drive*.py $PROJECT_LOCAL_ROOT/scripts/drive/subir_pendientes_drive.py
 
 # Copiar el task-script crontab.txt al directorio de proyectos
 cp $PROJECT_GIT_ROOT/scripts/task/crontab.txt $PROJECT_LOCAL_ROOT/scripts/task/

--- a/scripts/task/crontab.txt
+++ b/scripts/task/crontab.txt
@@ -1,3 +1,6 @@
+# Verifica cada 6 horas si existen archivos pendientes de subir a Drive:
+50 5,11,17,23 * * * /usr/local/bin/uploadpendingfiles
+
 # Reinicia el registro continuo cada 6 horas: 
 59 5,11,17,23 * * * /usr/local/bin/registrocontinuo stop
 0 */6 * * * /usr/local/bin/registrocontinuo start
@@ -5,8 +8,8 @@
 # Resetea el circuito al iniciar el sistem:
 @reboot sleep 30 && /usr/local/bin/resetmaster
 
-# Escanea y sube los archivos pendientes del directorio /resultados/mseed/ a Google Drive:
-@reboot sleep 60 && python3 /home/rsa/projects/acelerografo/scripts/drive/subir_archivos_pendientes.py 
+# Verifica si existen archivos pendientes de subir a Drive:
+@reboot sleep 60 && /usr/local/bin/uploadpendingfiles
 
 # Espera 90 segundos al arranque del sistema para ejecutar el registro continuo:
 @reboot sleep 90 && /usr/local/bin/registrocontinuo start

--- a/scripts/task/uploadpendingfiles.sh
+++ b/scripts/task/uploadpendingfiles.sh
@@ -4,6 +4,6 @@
 source /usr/local/bin/project_paths
 
 # Ejecutar el script
-/usr/bin/python3 $PROJECT_LOCAL_ROOT/scripts/drive/subir_archivos_pendientes.py
+/usr/bin/python3 $PROJECT_LOCAL_ROOT/scripts/drive/subir_pendientes_drive.py
 
 exit 0 

--- a/scripts/task/uploadpendingfiles.sh
+++ b/scripts/task/uploadpendingfiles.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Cargar las variables de entorno
+source /usr/local/bin/project_paths
+
+# Ejecutar el script
+/usr/bin/python3 $PROJECT_LOCAL_ROOT/scripts/drive/subir_archivos_pendientes.py
+
+exit 0 


### PR DESCRIPTION
Este PR incluye los siguientes cambios:

Corrección de errores:
Actualizado el nombre de los scripts ejecutados en los archivos task-script/uploadpendingfiles.sh y setup-script/deploy.sh.

Nuevas funcionalidades:
Implementado un nuevo task-script/uploadpendingfiles.sh que ejecuta el script de operación subir_archivos_pendientes.py.
Actualizado el archivo crontab para incluir la ejecución del nuevo script.

Cambios en progreso (WIP):
Modificado el script subir_archivo_2.0.0.py para que no cree el archivo de log directamente; ahora, el archivo drive.log es generado en el script de configuración setup-script/deploy.sh.
Resuelto el conflicto de nombres entre los scripts subir_archivo.py y subir_archivos_pendientes.py, renombrando este último a subir_pendientes_drive.py.

Estos cambios corrigen errores existentes, añaden una nueva funcionalidad para gestionar archivos pendientes y optimizan la gestión de logs y la nomenclatura de los scripts de operación.